### PR TITLE
すべてのPRでCIが動作するように設定を変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
       - main
       - develop
   pull_request:
-    branches:
-      - main
-      - develop
 
 jobs:
   test:


### PR DESCRIPTION
- pull_requestトリガーのbranches制限を削除
- これによりどのブランチへのPRでもCIが実行される
- pushトリガーはmain/developのまま維持