### PR TITLE
ci: CIチェックに日本語エラーハンドリングを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,18 +27,68 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        id: install
         run: pnpm install --frozen-lockfile
+        continue-on-error: true
+
+      - name: エラー - 依存関係のインストールに失敗しました
+        if: steps.install.outcome == 'failure'
+        run: |
+          echo "::error::❌ 依存関係のインストールに失敗しました"
+          echo "::error::pnpm install --frozen-lockfile が失敗しました。"
+          echo "::error::package.json や pnpm-lock.yaml を確認してください。"
+          exit 1
 
       - name: Check code formatting with Biome
+        id: format
         run: pnpm format:check
+        continue-on-error: true
+
+      - name: エラー - コードフォーマットチェックに失敗しました
+        if: steps.format.outcome == 'failure'
+        run: |
+          echo "::error::❌ コードフォーマットチェックに失敗しました"
+          echo "::error::Biomeのフォーマット規則に違反しているファイルがあります。"
+          echo "::error::修正するには 'pnpm format' を実行してください。"
+          exit 1
 
       - name: Type check
+        id: typecheck
         run: pnpm exec tsc --noEmit
+        continue-on-error: true
+
+      - name: エラー - 型チェックに失敗しました
+        if: steps.typecheck.outcome == 'failure'
+        run: |
+          echo "::error::❌ 型チェックに失敗しました"
+          echo "::error::TypeScriptの型エラーが検出されました。"
+          echo "::error::エラー内容を確認して、型定義を修正してください。"
+          exit 1
 
       - name: Run tests
+        id: test
         run: pnpm test
+        continue-on-error: true
+
+      - name: エラー - テストに失敗しました
+        if: steps.test.outcome == 'failure'
+        run: |
+          echo "::error::❌ テストに失敗しました"
+          echo "::error::一部のテストケースが失敗しました。"
+          echo "::error::テスト結果を確認して、コードを修正してください。"
+          exit 1
 
       - name: Build
+        id: build
         run: pnpm build
         env:
           NODE_ENV: production
+        continue-on-error: true
+
+      - name: エラー - ビルドに失敗しました
+        if: steps.build.outcome == 'failure'
+        run: |
+          echo "::error::❌ ビルドに失敗しました"
+          echo "::error::プロダクションビルドの作成に失敗しました。"
+          echo "::error::ビルドエラーを確認して、コードを修正してください。"
+          exit 1


### PR DESCRIPTION
各CIステップ（依存関係のインストール、フォーマットチェック、型チェック、
テスト、ビルド）に日本語のエラーメッセージを追加しました。

変更内容:
- 各主要ステップにIDを付与
- continue-on-errorを使用して失敗時も次のステップへ進行
- 失敗時に分かりやすい日本語のエラーメッセージを表示
- GitHub Actionsの::error::フォーマットで表示

これにより、CIが失敗した際に日本語で具体的なエラー内容と
対処方法が分かるようになります。